### PR TITLE
Fix yen problem

### DIFF
--- a/delicious-userscripts/concat_userscripts.py
+++ b/delicious-userscripts/concat_userscripts.py
@@ -69,7 +69,7 @@ def _main():
     os.chdir(os.path.dirname(__file__))
     Concat('./_ab_delicious_template.js').write_bundle(
         './dist/ab_delicious_scripts.user.js',
-        glob.glob('./src/*.user.js'))
+        sorted(glob.glob('./src/*.user.js')))
 
 if __name__ == '__main__':
     _main()

--- a/delicious-userscripts/dist/ab_delicious_scripts.user.js
+++ b/delicious-userscripts/dist/ab_delicious_scripts.user.js
@@ -2912,7 +2912,7 @@
     // @author      Megure, Lemma, NSC, et al.
     // @description Yen per X and ratio milestones, by Megure, Lemma, NSC, et al.
     // @include     https://animebytes.tv/user.php*
-    // @version     0.1.1
+    // @version     0.1.2
     // @icon        http://animebytes.tv/favicon.ico
     // @grant       GM_setValue
     // @grant       GM_getValue

--- a/delicious-userscripts/dist/ab_delicious_scripts.user.js
+++ b/delicious-userscripts/dist/ab_delicious_scripts.user.js
@@ -2940,7 +2940,7 @@
                 res = ',' + ('00' + (num % 1000)).slice(-3) + res;
                 num = Math.floor(num / 1000);
             }
-            return num + res;
+            return '¥' + num + res;
         }
         function bytecount(num, unit) {
             // For whatever reason, this was always called with .toUpperCase()
@@ -3013,14 +3013,14 @@
             return dt;
         }
         function addRawStats() {
-            var tw, regExp = /([0-9,.]+)\s*([A-Z]+)\s*\(([^)]*)\)/i;
+            var tw, regExp = /([0-9,.]+)\s*([A-Z]+)/i;
             // Find text with raw stats
             tw = document.createTreeWalker(document, NodeFilter.SHOW_TEXT, { acceptNode: function (node) { return /^Raw Uploaded:/i.test(node.data); } });
             if (tw.nextNode() == null) return;
-            var rawUpMatch = tw.currentNode.data.match(regExp);
+            var rawUpMatch = tw.currentNode.nextElementSibling.textContent.match(regExp);
             tw = document.createTreeWalker(tw.currentNode.parentNode.parentNode, NodeFilter.SHOW_TEXT, { acceptNode: function (node) { return /^Raw Downloaded:/i.test(node.data); } });
             if (tw.nextNode() == null) return;
-            var rawDownMatch = tw.currentNode.data.match(regExp);
+            var rawDownMatch = tw.currentNode.nextElementSibling.textContent.match(regExp);
             tw = document.createTreeWalker(document.getElementById('content'), NodeFilter.SHOW_TEXT, { acceptNode: function (node) { return /^\s*Ratio/i.test(node.data); } });
             if (tw.nextNode() == null) return;
             var ratioNode = tw.currentNode.parentNode;
@@ -3079,7 +3079,7 @@
             var tw = document.createTreeWalker(document.getElementById('content'), NodeFilter.SHOW_TEXT, { acceptNode: function (node) { return /Yen per day/i.test(node.data); } });
             if (tw.nextNode() == null) return;
             var ypdNode = tw.currentNode.parentNode;
-            var ypy = parseInt(ypdNode.nextElementSibling.textContent, 10) * dpy; // Yen per year
+            var ypy = parseInt(ypdNode.nextElementSibling.textContent.replace(/[,¥]/g, ''), 10) * dpy; // Yen per year
             addDefinitionAfter(ypdNode, 'Yen per year:', formatInteger(Math.round(ypy * compoundInterest(1))));
             addDefinitionAfter(ypdNode, 'Yen per month:', formatInteger(Math.round(ypy * compoundInterest(1 / 12))));
             addDefinitionAfter(ypdNode, 'Yen per week:', formatInteger(Math.round(ypy * compoundInterest(7 / dpy))));
@@ -3088,7 +3088,7 @@
             hr.style.clear = 'both';
             ypdNode.parentNode.insertBefore(hr, ypdNode);
             addDefinitionBefore(ypdNode, 'Yen as upload:', humancount(Math.pow(1024, 2) * ypy * compoundInterest(1 / dpy / 24 / 60 / 60)) + '/s');
-            addDefinitionBefore(ypdNode, 'Yen per hour:', (ypy * compoundInterest(1 / dpy / 24)).toFixed(1));
+            addDefinitionBefore(ypdNode, 'Yen per hour:', '¥' + (ypy * compoundInterest(1 / dpy / 24)).toFixed(1));
         }
         if (delicious.settings.get('deliciousratio'))
             addRawStats();

--- a/delicious-userscripts/src/ab_yen_stats.user.js
+++ b/delicious-userscripts/src/ab_yen_stats.user.js
@@ -108,10 +108,10 @@
         // Find text with raw stats
         tw = document.createTreeWalker(document, NodeFilter.SHOW_TEXT, { acceptNode: function (node) { return /^Raw Uploaded:/i.test(node.data); } });
         if (tw.nextNode() == null) return;
-        var rawUpMatch = tw.currentNode.data.match(regExp);
+        var rawUpMatch = tw.currentNode.nextElementSibling.textContent.match(regExp);
         tw = document.createTreeWalker(tw.currentNode.parentNode.parentNode, NodeFilter.SHOW_TEXT, { acceptNode: function (node) { return /^Raw Downloaded:/i.test(node.data); } });
         if (tw.nextNode() == null) return;
-        var rawDownMatch = tw.currentNode.data.match(regExp);
+        var rawDownMatch = tw.currentNode.nextElementSibling.textContent.match(regExp);
         tw = document.createTreeWalker(document.getElementById('content'), NodeFilter.SHOW_TEXT, { acceptNode: function (node) { return /^\s*Ratio/i.test(node.data); } });
         if (tw.nextNode() == null) return;
         var ratioNode = tw.currentNode.parentNode;

--- a/delicious-userscripts/src/ab_yen_stats.user.js
+++ b/delicious-userscripts/src/ab_yen_stats.user.js
@@ -170,7 +170,7 @@
         var tw = document.createTreeWalker(document.getElementById('content'), NodeFilter.SHOW_TEXT, { acceptNode: function (node) { return /Yen per day/i.test(node.data); } });
         if (tw.nextNode() == null) return;
         var ypdNode = tw.currentNode.parentNode;
-        var ypy = parseInt(ypdNode.nextElementSibling.textContent, 10) * dpy; // Yen per year
+        var ypy = parseInt(ypdNode.nextElementSibling.textContent.replace(/[,¥]/g, ''), 10) * dpy; // Yen per year
         addDefinitionAfter(ypdNode, 'Yen per year:', formatInteger(Math.round(ypy * compoundInterest(1))));
         addDefinitionAfter(ypdNode, 'Yen per month:', formatInteger(Math.round(ypy * compoundInterest(1 / 12))));
         addDefinitionAfter(ypdNode, 'Yen per week:', formatInteger(Math.round(ypy * compoundInterest(7 / dpy))));

--- a/delicious-userscripts/src/ab_yen_stats.user.js
+++ b/delicious-userscripts/src/ab_yen_stats.user.js
@@ -104,7 +104,7 @@
         return dt;
     }
     function addRawStats() {
-        var tw, regExp = /([0-9,.]+)\s*([A-Z]+)\s*\(([^)]*)\)/i;
+        var tw, regExp = /([0-9,.]+)\s*([A-Z]+)/i;
         // Find text with raw stats
         tw = document.createTreeWalker(document, NodeFilter.SHOW_TEXT, { acceptNode: function (node) { return /^Raw Uploaded:/i.test(node.data); } });
         if (tw.nextNode() == null) return;

--- a/delicious-userscripts/src/ab_yen_stats.user.js
+++ b/delicious-userscripts/src/ab_yen_stats.user.js
@@ -31,7 +31,7 @@
             res = ',' + ('00' + (num % 1000)).slice(-3) + res;
             num = Math.floor(num / 1000);
         }
-        return num + res;
+        return '¥' + num + res;
     }
     function bytecount(num, unit) {
         // For whatever reason, this was always called with .toUpperCase()
@@ -179,7 +179,7 @@
         hr.style.clear = 'both';
         ypdNode.parentNode.insertBefore(hr, ypdNode);
         addDefinitionBefore(ypdNode, 'Yen as upload:', humancount(Math.pow(1024, 2) * ypy * compoundInterest(1 / dpy / 24 / 60 / 60)) + '/s');
-        addDefinitionBefore(ypdNode, 'Yen per hour:', (ypy * compoundInterest(1 / dpy / 24)).toFixed(1));
+        addDefinitionBefore(ypdNode, 'Yen per hour:', '¥' + (ypy * compoundInterest(1 / dpy / 24)).toFixed(1));
     }
     if (delicious.settings.get('deliciousratio'))
         addRawStats();

--- a/delicious-userscripts/src/ab_yen_stats.user.js
+++ b/delicious-userscripts/src/ab_yen_stats.user.js
@@ -3,7 +3,7 @@
 // @author      Megure, Lemma, NSC, et al.
 // @description Yen per X and ratio milestones, by Megure, Lemma, NSC, et al.
 // @include     https://animebytes.tv/user.php*
-// @version     0.1.1
+// @version     0.1.2
 // @icon        http://animebytes.tv/favicon.ico
 // @grant       GM_setValue
 // @grant       GM_getValue


### PR DESCRIPTION
Fix the current problems with yen calculation.

The problem appears to be that the value of `Raw Uploaded` and `Raw Downloaded` is now inside a span next to the text. And the value of `Yen per day` have some extra symbols.

Also, I'm not sure how it was previously but by looking at the regex I assume there was a value in parentheses after the uploaded/downloaded value. This value is no longer there, and because this third capture group does not appear to be used anywhere I removed it from the regex.

One thing to note is that this new span for `Raw Uploaded`, `Raw Downloaded` and some other elements, have an attribute name `title` that have the value in bytes. It may be better to use this value instead of calculating the value with `bytecount()` and relaying on "MiB", "GiB", "TiB", etc.